### PR TITLE
Simplify header file a bit

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows an Arduino board with USB capabilites to act as a MIDI instrumen
 paragraph=
 category=Device Control
 url=http://www.arduino.cc/en/Reference/MIDIUSB
-architectures=*
+architectures=avr,sam,samd

--- a/src/MIDIUSB.h
+++ b/src/MIDIUSB.h
@@ -16,8 +16,6 @@
 #error MIDIUSB can only be used with an USB MCU.
 #endif
 
-#if defined(USBCON)
-
 typedef struct
 {
 	uint8_t header;
@@ -29,52 +27,56 @@ typedef struct
 #if defined(ARDUINO_ARCH_AVR)
 
 #include "PluggableUSB.h"
+
 #define EPTYPE_DESCRIPTOR_SIZE		uint8_t
-#define EP_TYPE_BULK_OUT_MIDI		EP_TYPE_BULK_OUT
-#define EP_TYPE_BULK_IN_MIDI		EP_TYPE_BULK_IN
-#define MIDI_BUFFER_SIZE			64
+#define EP_TYPE_BULK_IN_MIDI 		USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_IN(0);
+#define EP_TYPE_BULK_OUT_MIDI 		USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_OUT(0);
+#define MIDI_BUFFER_SIZE			USB_EP_SIZE
 #define is_write_enabled(x)			(1)
 
-#else
+#elif defined(ARDUINO_ARCH_SAM)
 
 #include "USB/PluggableUSB.h"
+
 #define EPTYPE_DESCRIPTOR_SIZE		uint32_t
-#define MIDI_BUFFER_SIZE			512
-
-#if defined(ARDUINO_ARCH_SAM)
-#define USB_SendControl         USBD_SendControl
-#define USB_Available           USBD_Available
-#define USB_Recv                USBD_Recv
-#define USB_Send                USBD_Send
-#define USB_Flush               USBD_Flush
-#define is_write_enabled(x)     Is_udd_write_enabled(x)
-
 #define EP_TYPE_BULK_IN_MIDI		(UOTGHS_DEVEPTCFG_EPSIZE_512_BYTE | \
 									UOTGHS_DEVEPTCFG_EPDIR_IN |         \
 									UOTGHS_DEVEPTCFG_EPTYPE_BLK |       \
 									UOTGHS_DEVEPTCFG_EPBK_1_BANK |      \
 									UOTGHS_DEVEPTCFG_NBTRANS_1_TRANS |  \
 									UOTGHS_DEVEPTCFG_ALLOC)
-
 #define EP_TYPE_BULK_OUT_MIDI       (UOTGHS_DEVEPTCFG_EPSIZE_512_BYTE | \
 									UOTGHS_DEVEPTCFG_EPTYPE_BLK |       \
 									UOTGHS_DEVEPTCFG_EPBK_1_BANK |      \
 									UOTGHS_DEVEPTCFG_NBTRANS_1_TRANS |  \
 									UOTGHS_DEVEPTCFG_ALLOC)
-#endif
+#define MIDI_BUFFER_SIZE			EPX_SIZE
+#define USB_SendControl				USBD_SendControl
+#define USB_Available				USBD_Available
+#define USB_Recv					USBD_Recv
+#define USB_Send					USBD_Send
+#define USB_Flush					USBD_Flush
+#define is_write_enabled(x)			Is_udd_write_enabled(x)
 
-#if defined(__SAMD21G18A__)
-#define USB_SendControl         USBDevice.sendControl
-#define USB_Available           USBDevice.available
-#define USB_Recv                USBDevice.recv
-#define USB_Send                USBDevice.send
-#define USB_Flush               USBDevice.flush
-#define is_write_enabled(x)     (1)
+#elif defined(ARDUINO_ARCH_SAMD)
 
+#include "USB/PluggableUSB.h"
+
+#define EPTYPE_DESCRIPTOR_SIZE		uint32_t
 #define EP_TYPE_BULK_IN_MIDI 		USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_IN(0);
 #define EP_TYPE_BULK_OUT_MIDI 		USB_ENDPOINT_TYPE_BULK | USB_ENDPOINT_OUT(0);
+#define MIDI_BUFFER_SIZE			EPX_SIZE
+#define USB_SendControl				USBDevice.sendControl
+#define USB_Available				USBDevice.available
+#define USB_Recv					USBDevice.recv
+#define USB_Send					USBDevice.send
+#define USB_Flush					USBDevice.flush
+#define is_write_enabled(x)			(1)
 
-#endif
+#else
+
+#error "Unsupported architecture"
+
 #endif
 
 #define MIDI_AUDIO								0x01
@@ -220,5 +222,4 @@ public:
 };
 extern MIDI_ MidiUSB;
 
-#endif	/* USBCON */
 #endif	/* MIDIUSB_h */


### PR DESCRIPTION
This removes some of the nested platform ```#ifdef``` statements and uses platform specific constants for endpoint size as the midi buffer size.

When used with https://github.com/arduino/ArduinoCore-samd/pull/102, Windows 8 reports the a Zero board as a sound device in the device manager (512 was being used as the MIDI buffer size, now 64 is used on SAMD). This might help resolve #8 when used with the SAMD PR. We still need to try it out with a MIDI program.

I've also removed the wildcard value for architectures in ```library.properties```.

cc/ @agdl @facchinm