### PR TITLE
Fix compile warning with latest Arduino IDEs because uint_8+1 convert…

### DIFF
--- a/src/MIDIUSB.cpp
+++ b/src/MIDIUSB.cpp
@@ -17,10 +17,10 @@
 #include "MIDIUSB.h"
 
 #define MIDI_AC_INTERFACE 	pluggedInterface	// MIDI AC Interface
-#define MIDI_INTERFACE 		pluggedInterface+1
+#define MIDI_INTERFACE 		((uint8_t)(pluggedInterface+1))
 #define MIDI_FIRST_ENDPOINT pluggedEndpoint
 #define MIDI_ENDPOINT_OUT	pluggedEndpoint
-#define MIDI_ENDPOINT_IN	pluggedEndpoint+1
+#define MIDI_ENDPOINT_IN	((uint8_t)(pluggedEndpoint+1))
 
 #define MIDI_RX MIDI_ENDPOINT_OUT
 #define MIDI_TX MIDI_ENDPOINT_IN


### PR DESCRIPTION
…ed into int instead of uint8_t, added parenthesis to avoid side effects in future when composing with these macros.
Now USBMIDI compiles warning free even in 'All Warnings' mode in the Arduino preferences !

Tested working with no regression on my interface.