### PR TITLE
Simple example of MIDI beat clock

### DIFF
--- a/examples/MIDIUSB_clock/MIDIUSB_clock.ino
+++ b/examples/MIDIUSB_clock/MIDIUSB_clock.ino
@@ -1,0 +1,69 @@
+/*
+ * MIDIUSB_clock.ino
+ * 
+ * Simple example of beat clock based on MIDI pulse messages
+ * received from software. 
+ * 
+ * Tested on Leonardo with Ableton.
+ * 
+ * In preferences go to MIDI Sync. Select device Output
+ * and toggle Sync button, change clock type to Pattern.
+ * Usually changing Sync Delay is required.
+ * 
+ * Created: 19/12/2016
+ * Author: Ernest Warzocha
+ */
+
+#include "MIDIUSB.h"
+
+//Pulse per quarter note. Each beat has 24 pulses.
+//Tempo is based on software inner BPM.
+int ppqn = 0;
+
+void noteOn(byte channel, byte pitch, byte velocity) {
+  midiEventPacket_t noteOn = {0x09, 0x90 | channel, pitch, velocity};
+  MidiUSB.sendMIDI(noteOn);
+}
+
+void noteOff(byte channel, byte pitch, byte velocity) {
+  midiEventPacket_t noteOff = {0x08, 0x80 | channel, pitch, velocity};
+  MidiUSB.sendMIDI(noteOff);
+}
+
+void setup() {
+  Serial.begin(115200);
+}
+
+void loop() {
+  
+  midiEventPacket_t rx;
+  
+  do {
+    rx = MidiUSB.read();
+
+    //Count pulses and send note 
+    if(rx.byte1 == 0xF8){
+       ++ppqn;
+       
+       if(ppqn == 24){
+          noteOn(1,48,127);
+          MidiUSB.flush();      
+          ppqn = 0;
+       };
+    }
+    //Clock start byte
+    else if(rx.byte1 == 0xFA){
+      noteOn(1,48,127);
+      MidiUSB.flush();
+      ppqn = 0;
+    }
+    //Clock stop byte
+    else if(rx.byte1 == 0xFC){
+      noteOff(1,48,0);
+      MidiUSB.flush();
+      ppqn = 0;
+    };
+    
+  } while (rx.header != 0);
+  
+}


### PR DESCRIPTION
Hi,

I was working on MIDI project with Arduino and Ableton, at some point I had to use MIDI beat clock with this library.

I decided to create a basic example of this to help others. It syncs the Arduino (tested on Leonardo) with software midi clock and BPM in Ableton (and plays single note).

I think that I'm not the only one who could reuse this code for simple audio device. At last it can be used as some kind of boilerplate for any project.

PS. If something in code could be better feel free to change.