### PR TITLE
Move event packet type declaration into a separate header

### DIFF
--- a/src/MIDIUSB.h
+++ b/src/MIDIUSB.h
@@ -18,7 +18,7 @@
 #error MIDIUSB can only be used with an USB MCU.
 #endif
 
-#include "./MIDIUSB_Defs.h"
+#include "MIDIUSB_Defs.h"
 
 #if defined(ARDUINO_ARCH_AVR)
 

--- a/src/MIDIUSB.h
+++ b/src/MIDIUSB.h
@@ -18,13 +18,7 @@
 #error MIDIUSB can only be used with an USB MCU.
 #endif
 
-typedef struct
-{
-	uint8_t header;
-	uint8_t byte1;
-	uint8_t byte2;
-	uint8_t byte3;
-}midiEventPacket_t;
+#include "./MIDIUSB_Defs.h"
 
 #if defined(ARDUINO_ARCH_AVR)
 

--- a/src/MIDIUSB_Defs.h
+++ b/src/MIDIUSB_Defs.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stdint.h>
+
+struct midiEventPacket_t
+{
+	uint8_t header;
+	uint8_t byte1;
+	uint8_t byte2;
+	uint8_t byte3;
+};

--- a/src/MIDIUSB_Defs.h
+++ b/src/MIDIUSB_Defs.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <stdint.h>
 
-struct midiEventPacket_t
+typedef struct
 {
 	uint8_t header;
 	uint8_t byte1;
 	uint8_t byte2;
 	uint8_t byte3;
-};
+} midiEventPacket_t;


### PR DESCRIPTION
This would allow 3rd party code to work with this data type without including the whole interface code, which is environment-specific.

See issue #21.