### PR TITLE
Support the megaavr architecture (AVR-Dx/DU via DxCore)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows an Arduino board with USB capabilities to act as a MIDI instrume
 paragraph=
 category=Device Control
 url=http://www.arduino.cc/en/Reference/MIDIUSB
-architectures=avr,sam,samd
+architectures=avr,megaavr,sam,samd

--- a/src/MIDIUSB.h
+++ b/src/MIDIUSB.h
@@ -20,7 +20,7 @@
 
 #include "MIDIUSB_Defs.h"
 
-#if defined(ARDUINO_ARCH_AVR)
+#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_MEGAAVR)
 
 #include "PluggableUSB.h"
 


### PR DESCRIPTION
## Summary

Enable MIDIUSB on the `megaavr` architecture, for the new AVR-DU series (e.g. AVR64DU32) 
— AVR `megaavr`-architecture parts that have a native USB peripheral.
These are supported via DxCore, which presents USB through the same Pluggable USB API as classic AVR.

## Background

No `megaavr` part previously shipped with native USB, so MIDIUSB has notneeded a megaavr branch until now.
The AVR-DU series is a `megaavr`-architecture device with a built-in USB 2.0 full-speedperipheral, 
and DxCore exposes it through the standard Arduino PluggableUSB API — the same API MIDIUSB already uses on classic AVR.

I'm adding AVR-DU support to DxCore (SpenceKonde/DxCore#637, draft).
With that in place, MIDIUSB builds and runs on the DU, except that its preprocessor guards only recognize `ARDUINO_ARCH_AVR`.
This PR addresses that.

## Changes

- **src/MIDIUSB.h**: extend the existing `ARDUINO_ARCH_AVR` branch to also cover `ARDUINO_ARCH_MEGAAVR`.
  The branch's body (PluggableUSB.h include,`EPTYPE_DESCRIPTOR_SIZE = uint8_t`) applies unchanged to megaavr.
- **library.properties**: add `megaavr` to the `architectures` list.

## Testing

Verified on an AVR64DU32 (Curiosity Nano) via DxCore: the MIDIUSB_read and MIDIUSB_write examples
both work (MIDI in/out confirmed with MIDI-OX),with `Serial` (USB CDC) active in the same sketch.

No behavior change on existing targets — the megaavr path reuses the classic-AVR branch unchanged,
and AVR/SAM/SAMD builds are unaffected.

## Note

xCore's DU support (SpenceKonde/DxCore#637) is still a draft and not yet merged.
This MIDIUSB change is small and self-contained, but if you'd prefer to wait until DU support is publicly availablein DxCore before merging,
that's completely understandable — I wanted to submit it now so the megaavr gap is documented and tracked.